### PR TITLE
Create collection image from the original image_url

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -39,8 +39,4 @@ class Collection < ActiveRecord::Base
   def published?
     !!published_at
   end
-
-  def image_url
-    image.present? ? image.url : read_attribute(:image_url)
-  end
 end

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -4,7 +4,6 @@ class Transcript < ActiveRecord::Base
 
   mount_uploader :image, ImageUploader
   mount_uploader :audio, AudioUploader
-  mount_uploader :script, TranscriptUploader
 
   include PgSearch
   multisearchable :against => [:title, :description]
@@ -23,6 +22,8 @@ class Transcript < ActiveRecord::Base
   has_many :transcript_edits
   has_many :transcript_speakers
 
+  # speakers getters and setters used to manage the transcript_speakers
+  # when creating or editing a transcript
   def speakers
     return "" if transcript_speakers.blank?
     transcript_speakers.includes(:speaker).pluck(:name).join("; ") + "; "

--- a/app/uploaders/transcript_uploader.rb
+++ b/app/uploaders/transcript_uploader.rb
@@ -1,9 +1,0 @@
-class TranscriptUploader < CarrierWave::Uploader::Base
-  include S3Identifier
-
-  # Override the directory where uploaded files will be stored.
-  # This path will be appended to the S3 bucket url.
-  def store_dir
-    "collections/#{s3_collection_uid}/transcripts/"
-  end
-end

--- a/app/views/admin/cms/collections/_item_list.html.erb
+++ b/app/views/admin/cms/collections/_item_list.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div class="col-1">
-      <%= check_box_tag :transcript_url, 'uploaded', item.present? %>
+      <%= check_box_tag :transcript_url, 'uploaded', true %>
     </div>
     <div class="col-1">
       <%= check_box_tag :is_published, item.is_published? %>

--- a/app/views/admin/cms/collections/_item_list.html.erb
+++ b/app/views/admin/cms/collections/_item_list.html.erb
@@ -3,11 +3,11 @@
     <div class="col-2"><%= item.uid %></div>
     <div class="col-4"><%= item.title %></div>
     <div class="col-2">
-      <%= image_tag(item.image.thumb) if item.image.present? %>
+      <%= image_tag(item.thumb) if item.image.url.present? %>
     </div>
 
     <div class="col-1">
-      <%= check_box_tag :transcript_url, 'uploaded', item.script_url.present? %>
+      <%= check_box_tag :transcript_url, 'uploaded', item.script.url.present? %>
     </div>
     <div class="col-1">
       <%= check_box_tag :is_published, item.is_published? %>

--- a/app/views/admin/cms/collections/_item_list.html.erb
+++ b/app/views/admin/cms/collections/_item_list.html.erb
@@ -3,11 +3,11 @@
     <div class="col-2"><%= item.uid %></div>
     <div class="col-4"><%= item.title %></div>
     <div class="col-2">
-      <%= image_tag(item.thumb) if item.image.url.present? %>
+      <%= image_tag(item.image.thumb) if item.image.url.present? %>
     </div>
 
     <div class="col-1">
-      <%= check_box_tag :transcript_url, 'uploaded', item.script.url.present? %>
+      <%= check_box_tag :transcript_url, 'uploaded', item.present? %>
     </div>
     <div class="col-1">
       <%= check_box_tag :is_published, item.is_published? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,4 +22,5 @@
 en:
   errors:
     messages:
-      content_type_whitelist_error: "Unable to upload that type of file"
+      content_type_whitelist_error: "You are not allowed to upload %{content_type} files"
+      mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"

--- a/lib/tasks/s3_file_conversion.rake
+++ b/lib/tasks/s3_file_conversion.rake
@@ -1,0 +1,39 @@
+require 'fileutils'
+include CarrierWave::MiniMagick
+
+namespace :s3 do
+  # Usage:
+  #     rake s3:file_conversion
+  desc "convert manually uploaded files to carrierwave objects"
+  task file_conversion: :environment do |task, args|
+    records = []
+
+    [Collection, Transcript].each do |klass|
+      klass.where.not(image_url: nil).find_each do |resource|
+        image_url = resource.read_attribute(:image_url)
+
+        if image_url.present? && resource.image.blank?
+            records << resource
+
+            dir_name = FileUtils.mkpath('tmp/s3_uploads/')
+            file_name = File.basename(image_url)
+            file_path = File.join(dir_name, file_name)
+
+            # Download the image from S3 and store in temp folder.
+            File.open(file_path, 'wb') do |file|
+              file.write open(image_url).read
+            end
+
+            # Upload the image from disk.
+            resource.vendor = Vendor.find_by uid: "voice_base"
+            resource.image = Rails.root.join('tmp', 's3_uploads', file_name).open
+            resource.save
+
+            print "."
+        end
+      end
+
+      puts "Updated #{records.count} records"
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149376333

By adding Carrierwave to the Collection and Transcript models the existing the existing image_url attribute would not return the original s3 file url. 

CarrierWave overrides this method and returns nil if the image column on the model does have a file associated.

`read_attribute(:iamge_url)` should be used to access the original image urls.

To avoid having to change all the references to this column in the existing views, the original images has been associated with the new image column as well. This has the extra benefit of allowing access to the MiniMagick image resizing.