### PR TITLE
Rake tasks to convert original s3 files to carrierwave objects

### DIFF
--- a/app/uploaders/audio_uploader.rb
+++ b/app/uploaders/audio_uploader.rb
@@ -4,6 +4,6 @@ class AudioUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This path will be appended to the S3 bucket url.
   def store_dir
-    "collections/#{s3_collection_uid}/audio/"
+    "collections_v2/#{s3_collection_uid}/audio/"
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -10,7 +10,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This path will be appended to the S3 bucket url.
   def store_dir
-    "collections/#{s3_collection_uid}/images/"
+    "collections_v2/#{s3_collection_uid}/images/"
   end
 
   # Create different versions of your uploaded files:

--- a/lib/tasks/s3_file_conversion.rake
+++ b/lib/tasks/s3_file_conversion.rake
@@ -1,47 +1,113 @@
 require 'fileutils'
+require 'open-uri'
 include CarrierWave::MiniMagick
 
 namespace :s3 do
   # Usage:
   #     rake s3:file_conversion
   desc "convert manually uploaded files to carrierwave objects"
-  task file_conversion: :environment do |task, args|
+  task image_conversion: :environment do |task|
+    success = []
+    errors = []
+
+    voice_base = Vendor.find_by uid: "voice_base"
+
+    [Collection, Transcript].each do |klass|
+      klass.find_each do |resource|
+        # CarrierWave introduces an image_url which overrides the call to
+        # the model attribute so we need to use read_attribute to access it
+        image_url = resource.read_attribute(:image_url)
+        puts "*** IMAGE URL: #{image_url}"
+
+        if image_url.present? && resource.image.blank?
+          puts "*** CONVERT IMAGE ***"
+
+          # Setup to store file from S3 bucket
+          dir_name = FileUtils.mkpath('tmp/s3_uploads/')
+          file_name = File.basename(image_url)
+          file_path = File.join(dir_name, file_name)
+
+          # Download the image from S3 and store in temp folder.
+          # * open the tmp file
+          # * fetch the image from s3
+          # * write the content to the tmp file
+          puts "*** START WRITING ***"
+          open(file_path, 'wb') do |file|
+            file.write open(image_url).read
+          end
+
+          # Save the remote image to the model's uploader column
+          # On save the image will overwrite the remote file with the same name
+          puts "*** UPDATE RESOURCE ***"
+          resource.vendor = voice_base
+          resource.image = Rails.root.join('tmp', 's3_uploads', file_name).open
+
+          if resource.save!
+            puts "*** SAVING ***"
+            success << resource
+          else
+            puts "*** FAILED ***"
+            errors << resource
+          end
+        end
+      end
+    end
+    print_result(success, errors)
+  end
+
+  task audio_conversion: :environment do |task|
     success = []
     errors = []
     voice_base = Vendor.find_by uid: "voice_base"
 
-    [Collection, Transcript].each do |klass|
-      klass.where.not(image_url: nil).find_each do |resource|
-        image_url = resource.read_attribute(:image_url)
+    Transcript.find_each do |transcript|
+      # CarrierWave introduces an image_url which overrides the call to the
+      # model attribute so we need to use read_attribute to access it
+      audio_url = transcript.read_attribute(:audio_url)
+      puts "*** AUDIO URL: #{audio_url}"
 
-        if image_url.present? && resource.image.blank?
-            dir_name = FileUtils.mkpath('tmp/s3_uploads/')
-            file_name = File.basename(image_url)
-            file_path = File.join(dir_name, file_name)
+      if audio_url.present? && transcript.audio.blank?
+        puts "*** CONVERT AUDIO ***"
+        # Setup to store file from S3 bucket
+        dir_name = FileUtils.mkpath('tmp/s3_uploads/')
+        file_name = File.basename(audio_url)
+        file_path = File.join(dir_name, file_name)
 
-            # Download the image from S3 and store in temp folder.
-            File.open(file_path, 'wb') do |file|
-              file.write open(image_url).read
-            end
+        # Download the audio files from S3 and store in temp folder.
+        # * open the tmp file
+        # * fetch the audio file from s3
+        # * write the content to the tmp file
+        puts "*** START WRITING ***"
+        open(file_path, 'wb') do |file|
+          file.write open(audio_url).read
+        end
 
-            # Upload the image from disk.
-            resource.vendor = voice_base
-            resource.image = Rails.root.join('tmp', 's3_uploads', file_name).open
+        # Save the remote audio to the model's uploader column
+        # when save the audio will be overwrite the remote file with the same name
+        puts "*** UPDATE TRANSCRIPT ***"
+        transcript.vendor = voice_base
+        transcript.audio = Rails.root.join('tmp', 's3_uploads', file_name).open
 
-            if resource.save
-              success << resource
-            else
-              errors << resource
-            end
+        if transcript.save!
+          puts "*** SAVING ***"
+          success << transcript
+        else
+          puts "*** FAILED ***"
+          errors << transcript
         end
       end
+    end
+    print_result(success, errors)
+  end
 
-      if success.empty? && errors.empty?
-        puts "No records needed to be updated"
-      else
-        puts "Updated #{success.count} records"
-        puts "Failed to update the #{errors.count} records"
-        errors.each { |el| puts "* #{el.class} - #{el.uid}" }
+  def print_result(success, errors)
+    if success.empty? && errors.empty?
+      puts "*** NO RECORDS TO UPDATE ***"
+    else
+      puts "*** UPDATED #{success.count} RECORDS ***"
+      puts "*** FAILED TO UPDATE #{errors.count} RECORDS ***"
+      errors.each do |el|
+        puts "* #{el.class} - #{el.read_attribute(:audio_url)}"
       end
     end
   end

--- a/lib/tasks/s3_file_conversion.rake
+++ b/lib/tasks/s3_file_conversion.rake
@@ -79,6 +79,6 @@ namespace :s3 do
   end
 
   def log_result(error)
-    File.write('tmp/s3_uploads/carrierwave_uploader_log.txt', "#{error} \n")
+    File.write("log/carrierwave_uploader_#{Time.current}.log", "#{error} \n")
   end
 end

--- a/lib/tasks/s3_file_conversion.rake
+++ b/lib/tasks/s3_file_conversion.rake
@@ -12,47 +12,45 @@ namespace :s3 do
 
     voice_base = Vendor.find_by uid: "voice_base"
 
-    [Collection, Transcript].each do |klass|
-      klass.find_each do |resource|
-        # CarrierWave introduces an image_url which overrides the call to
-        # the model attribute so we need to use read_attribute to access it
-        image_url = resource.read_attribute(:image_url)
-        puts "*** IMAGE URL: #{image_url}"
+    begin
+      [Collection, Transcript].each do |klass|
+        klass.find_each do |resource|
+          # CarrierWave introduces an image_url which overrides the call to
+          # the model attribute so we need to use read_attribute to access it
+          image_url = resource.read_attribute(:image_url)
 
-        if image_url.present? && resource.image.blank?
-          puts "*** CONVERT IMAGE ***"
+          if image_url.present? && resource.image.blank?
+            # Setup to store file from S3 bucket
+            dir_name = FileUtils.mkpath('tmp/s3_uploads/')
+            file_name = File.basename(image_url)
+            file_path = File.join(dir_name, file_name)
 
-          # Setup to store file from S3 bucket
-          dir_name = FileUtils.mkpath('tmp/s3_uploads/')
-          file_name = File.basename(image_url)
-          file_path = File.join(dir_name, file_name)
+            # Download the image from S3 and store in temp folder.
+            # * open the tmp file
+            # * fetch the image from s3
+            # * write the content to the tmp file
+            open(file_path, 'wb') do |file|
+              file.write open(image_url).read
+            end
 
-          # Download the image from S3 and store in temp folder.
-          # * open the tmp file
-          # * fetch the image from s3
-          # * write the content to the tmp file
-          puts "*** START WRITING ***"
-          open(file_path, 'wb') do |file|
-            file.write open(image_url).read
-          end
+            # Save the remote image to the model's uploader column
+            # On save the image will overwrite the remote file with the same name
+            resource.vendor = voice_base
+            resource.image = Rails.root.join('tmp', 's3_uploads', file_name).open
 
-          # Save the remote image to the model's uploader column
-          # On save the image will overwrite the remote file with the same name
-          puts "*** UPDATE RESOURCE ***"
-          resource.vendor = voice_base
-          resource.image = Rails.root.join('tmp', 's3_uploads', file_name).open
-
-          if resource.save!
-            puts "*** SAVING ***"
-            success << resource
-          else
-            puts "*** FAILED ***"
-            errors << resource
+            if resource.save!
+              success << resource
+            else
+              errors << resource
+            end
           end
         end
       end
+    rescue => StandardError => e
+      print_result(errors: e)
     end
-    print_result(success, errors)
+
+    print_result(success: success, errors: errors)
   end
 
   task audio_conversion: :environment do |task|
@@ -60,14 +58,13 @@ namespace :s3 do
     errors = []
     voice_base = Vendor.find_by uid: "voice_base"
 
-    Transcript.find_each do |transcript|
+    begin
+      Transcript.find_each do |transcript|
       # CarrierWave introduces an image_url which overrides the call to the
       # model attribute so we need to use read_attribute to access it
       audio_url = transcript.read_attribute(:audio_url)
-      puts "*** AUDIO URL: #{audio_url}"
 
       if audio_url.present? && transcript.audio.blank?
-        puts "*** CONVERT AUDIO ***"
         # Setup to store file from S3 bucket
         dir_name = FileUtils.mkpath('tmp/s3_uploads/')
         file_name = File.basename(audio_url)
@@ -77,36 +74,39 @@ namespace :s3 do
         # * open the tmp file
         # * fetch the audio file from s3
         # * write the content to the tmp file
-        puts "*** START WRITING ***"
         open(file_path, 'wb') do |file|
           file.write open(audio_url).read
         end
 
         # Save the remote audio to the model's uploader column
         # when save the audio will be overwrite the remote file with the same name
-        puts "*** UPDATE TRANSCRIPT ***"
         transcript.vendor = voice_base
         transcript.audio = Rails.root.join('tmp', 's3_uploads', file_name).open
 
         if transcript.save!
-          puts "*** SAVING ***"
           success << transcript
         else
-          puts "*** FAILED ***"
           errors << transcript
         end
       end
     end
-    print_result(success, errors)
+    rescue StandardError => e
+      print_result(errors: e)
+    end
+
+    print_result(success: success, errors: errors)
   end
 
-  def print_result(success, errors)
-    if success.empty? && errors.empty?
+  def print_result(args)
+    if args[:success].empty? && args[:errors].empty?
       puts "*** NO RECORDS TO UPDATE ***"
+    elsif args[:success].empty? && args[:errors].present?
+      puts "*** FAILED TO UPDATE ***"
+      puts args[:errors]
     else
-      puts "*** UPDATED #{success.count} RECORDS ***"
-      puts "*** FAILED TO UPDATE #{errors.count} RECORDS ***"
-      errors.each do |el|
+      puts "*** UPDATED #{args[:success].count} RECORDS ***"
+      puts "*** FAILED TO UPDATE #{args[:errors].count} RECORDS ***"
+      args[:errors].each do |el|
         puts "* #{el.class} - #{el.read_attribute(:audio_url)}"
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149376333

Two rake tasks, namespaced to S3, added to manage the conversion of the original images and audio files respectively. The original files were uploaded to S3 manually and their location in the S3 buckets were stored in the image_url and audio_url object attributes.

Link to PR on the Reinteractive repository: https://github.com/reinteractive/nsw-state-library-amplify/pull/1