### PR TITLE
Improved s3 coversions

### DIFF
--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -4,6 +4,7 @@ class Transcript < ActiveRecord::Base
 
   mount_uploader :image, ImageUploader
   mount_uploader :audio, AudioUploader
+  mount_uploader :script, TranscriptUploader
 
   include PgSearch
   multisearchable :against => [:title, :description]

--- a/app/uploaders/transcript_uploader.rb
+++ b/app/uploaders/transcript_uploader.rb
@@ -1,0 +1,12 @@
+class TranscriptUploader < CarrierWave::Uploader::Base
+  include S3Identifier
+
+  storage :file
+
+  # The audio files are converted to transcript.srt files by the VoiceBase vendor
+  # these files are stored within the project directory. There are existing
+  # rake tasks that reference these files and support the content review process.
+  def store_dir
+    "#{Rails.root}/project/#{ENV['PROJECT_ID']}/transcripts/voice_base/"
+  end
+end

--- a/lib/tasks/s3_file_conversion.rake
+++ b/lib/tasks/s3_file_conversion.rake
@@ -9,9 +9,9 @@ namespace :s3 do
   task image_conversion: :environment do |task|
     voice_base = Vendor.find_by uid: "voice_base"
 
-    begin
-      [Collection, Transcript].each do |klass|
-        klass.find_each do |resource|
+    [Collection, Transcript].each do |klass|
+      klass.find_each do |resource|
+        begin
           # CarrierWave introduces an image_url which overrides the call to
           # the model attribute so we need to use read_attribute to access it
           image_url = resource.read_attribute(:image_url)
@@ -36,49 +36,51 @@ namespace :s3 do
             resource.image = Rails.root.join('tmp', 's3_uploads', file_name).open
             resource.save!
           end
+
+        rescue StandardError => e
+          log_result("#{e} => #{image_url}")
         end
       end
-    rescue StandardError => e
-      log_result(e)
     end
   end
 
   task audio_conversion: :environment do |task|
     voice_base = Vendor.find_by uid: "voice_base"
 
-    begin
-      Transcript.find_each do |transcript|
-      # CarrierWave introduces an image_url which overrides the call to the
-      # model attribute so we need to use read_attribute to access it
-      audio_url = transcript.read_attribute(:audio_url)
+    Transcript.find_each do |transcript|
+      begin
+        # CarrierWave introduces an image_url which overrides the call to the
+        # model attribute so we need to use read_attribute to access it
+        audio_url = transcript.read_attribute(:audio_url)
 
-      if audio_url.present? && transcript.audio.blank?
-        # Setup to store file from S3 bucket
-        dir_name = FileUtils.mkpath('tmp/s3_uploads/')
-        file_name = File.basename(audio_url)
-        file_path = File.join(dir_name, file_name)
+        if audio_url.present? && transcript.audio.blank?
+          # Setup to store file from S3 bucket
+          dir_name = FileUtils.mkpath('tmp/s3_uploads/')
+          file_name = File.basename(audio_url)
+          file_path = File.join(dir_name, file_name)
 
-        # Download the audio files from S3 and store in temp folder.
-        # * open the tmp file
-        # * fetch the audio file from s3
-        # * write the content to the tmp file
-        open(file_path, 'wb') do |file|
-          file.write open(audio_url).read
+          # Download the audio files from S3 and store in temp folder.
+          # * open the tmp file
+          # * fetch the audio file from s3
+          # * write the content to the tmp file
+          open(file_path, 'wb') do |file|
+            file.write open(audio_url).read
+          end
+
+          # Save the remote audio to the model's uploader column
+          # when save the audio will be overwrite the remote file with the same name
+          transcript.vendor = voice_base
+          transcript.audio = Rails.root.join('tmp', 's3_uploads', file_name).open
+          transcript.save!
         end
 
-        # Save the remote audio to the model's uploader column
-        # when save the audio will be overwrite the remote file with the same name
-        transcript.vendor = voice_base
-        transcript.audio = Rails.root.join('tmp', 's3_uploads', file_name).open
-        transcript.save!
+      rescue StandardError => e
+        log_result("#{e} => #{audio_url}")
       end
-    end
-    rescue StandardError => e
-      log_result(e)
     end
   end
 
   def log_result(error)
-    File.write("log/carrierwave_uploader_#{Time.current}.log", "#{error} \n")
+    File.write("log/carrierwave_uploader_#{Time.current.to_i}.log", "#{error}")
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149702849

* Additional log output added to rake tasks to assist with failed AWS S3 bucket file conversions to CarrierWave format.
* Storage of transcript files in the project directory instead of AWS S3 bucket. Existing files are stored here that are referenced by other rake tasks to support the transcript review process.

Reinteractive PR reference https://github.com/reinteractive/nsw-state-library-amplify/pull/3